### PR TITLE
hotfix(schema): swap validation order

### DIFF
--- a/layers/form/validators/authRules.ts
+++ b/layers/form/validators/authRules.ts
@@ -19,9 +19,9 @@ export const signUpSchema = yup.object({
         .min(6, "Username must be at least 6 characters long"),
     email: yup
         .string()
+        .required('Email is required')
         .min(6, "Email must be at least 6 characters long")
-        .email('Please enter a valid email address')
-        .required('Email is required'),
+        .email('Please enter a valid email address'),
     password: yup
         .string()
         .required('Password is required')


### PR DESCRIPTION
Validation order adjustments:

* [`layers/form/validators/authRules.ts`](diffhunk://#diff-f46159773836304df0982e5e45c4632ffa8349755fb048dfdfee1c0e5e782064L7-R28): Reordered the validation rules in `signInSchema` and `signUpSchema` so that the `required` rule precedes the `min` length rule for `email`, `password`, and `username` fields. This improves the clarity of validation error messages by prioritizing the "required" error over the "minimum length" error.