### PR TITLE
hotfix(catch): console error has been removed

### DIFF
--- a/pages/sign.vue
+++ b/pages/sign.vue
@@ -61,7 +61,6 @@ const sign = async (payload: typeof state) => {
 
     await router.push("/")
   } catch (error: unknown) {
-    console.error(error)
 
     errorToast(error as Strapi5Error, {
       orientation: "horizontal",


### PR DESCRIPTION
This pull request makes a small change to the error handling logic in the `sign` function within the `pages/sign.vue` file. The change removes a redundant `console.error` statement, simplifying the code.