### PR TITLE
chore(workflows): removed PR trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ name: Run Tests
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   test:


### PR DESCRIPTION
This pull request includes a minor update to the GitHub Actions workflow configuration file. The change removes the trigger for running tests on pull requests to branches named `master`.