### PR TITLE
update: using the try/catch block to handle the http 401 error

### DIFF
--- a/layers/user/middleware/auth.ts
+++ b/layers/user/middleware/auth.ts
@@ -4,11 +4,11 @@ export default defineNuxtRouteMiddleware(async (to, _from) => {
 
     const {me} = useAuth()
 
-    if (!user.value) {
-        await me()
-    }
-
-    if (!user.value) {
+    try {
+        if (!user.value) {
+            await me()
+        }
+    } catch (e) {
         useCookie('redirect', { path: '/', httpOnly: true, secure: true, sameSite: 'strict' }).value = to.fullPath
         return navigateTo('/sign')
     }


### PR DESCRIPTION
Wrapped the call to `me()` and the user authentication check in a `try/catch` block to handle errors gracefully, ensuring users are redirected to the sign-in page if an error occurs during authentication.