### PR TITLE
Removed UI layer from Nuxt config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -12,7 +12,6 @@ export default defineNuxtConfig({
     css: ['~/assets/css/main.css'],
     extends: [
         "./layers/form",
-        "./layers/ui",
         "./layers/base",
         "./layers/bookmark",
     ],


### PR DESCRIPTION
This pull request makes a small change to the Nuxt configuration by removing the `ui` layer from the list of extended layers in `nuxt.config.ts`.