### PR TITLE
fix(fonts): switch provider to bunny

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,5 +22,8 @@ export default defineNuxtConfig({
             strapiOrigin: ""
         }
     },
-    ssr: false
+    ssr: false,
+    fonts: {
+        provider: "bunny"
+    }
 })


### PR DESCRIPTION
This PR fixes an issue where the fontshare provider could not be initialized, causing unifont to fail to process fonts.